### PR TITLE
(再)環境ファイルの例を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+RESAS_API_URL=https://opendata.resas-portal.go.jp
+RESAS_API_KEY=your_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*
-!.env.example
+# local
 .local
 
 # vercel
@@ -34,4 +32,5 @@ yarn-error.log*
 *.tsbuildinfo
 
 # env
-.env.*
+.env*
+!.env.example


### PR DESCRIPTION
このPRには以下の変更が含まれています。

- .env.exampleとして環境ファイルの例を追加。

一つ前のPRにて、.gitignoreの設定を見落としていたことにより、正常に反映がされていなかったため、再度追加PRを発行。