### PR TITLE
Homeで利用するモジュールパーツの作成

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,8 @@
         "eslint:recommended",
         "plugin:react/recommended",
         "plugin:react-hooks/recommended",
-        "plugin:storybook/recommended"
+        "plugin:storybook/recommended",
+        "prettier"
     ],
     "parserOptions": {
         "ecmaVersion": "latest",

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # env
 .env*
 !.env.example
+
+# storybook
+storybook-static

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/react-dom": "^18.2.18",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard-with-typescript": "^43.0.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-n": "^16.4.0",

--- a/src/api/resas/compositions.ts
+++ b/src/api/resas/compositions.ts
@@ -1,7 +1,9 @@
 import useSWR, { type SWRConfiguration } from 'swr'
+import useSWRInfinite, { type SWRInfiniteConfiguration } from 'swr/infinite'
 import { resasGet } from '../fetcher'
 import { type AxiosError } from 'axios'
 import { type Composition } from '../../types'
+import { useCallback } from 'react'
 
 export const useComposition = (
   prefCode: number,
@@ -13,4 +15,31 @@ export const useComposition = (
     resasGet,
     options
   )
+}
+
+export const useCompositions = (
+  prefCodes: number[],
+  cityCodes?: string[],
+  options?: SWRInfiniteConfiguration
+) => {
+  const { data: originalData, setSize, ...other } = useSWRInfinite<Composition, AxiosError>(
+    (index: number, previousPageData: Composition) => {
+      if (previousPageData && !previousPageData) return null
+      const prefCode = prefCodes[index]
+      const cityCode = cityCodes ? cityCodes[index] : '-'
+      return `/api/v1/population/composition/perYear?cityCode=${cityCode}&prefCode=${prefCode}`
+    },
+    resasGet,
+    options
+  )
+
+  const data = originalData?.map((composition, index) => {
+    return {prefCode: prefCodes[index], ...composition}
+  })
+
+  const allLoad = useCallback(async () => {
+    await setSize(prefCodes.length)
+  }, [setSize, prefCodes.length])
+
+  return { data, setSize, allLoad, ...other }
 }

--- a/src/components/CheckBox/index.stories.tsx
+++ b/src/components/CheckBox/index.stories.tsx
@@ -7,6 +7,7 @@ export default {
   component: CheckBox,
   argTypes: {
     label: { control: 'text' },
+    value: { control: 'text' },
     checked: { control: 'boolean' },
     disabled: { control: 'boolean' },
     style: { control: 'object' }
@@ -17,10 +18,11 @@ type Story = StoryObj<typeof CheckBox>
 
 const Template = (args: {
   label: string
+  value?: string | number
   checked?: boolean
   disabled?: boolean
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
-  style: React.CSSProperties
+  style?: React.CSSProperties
 }) => <CheckBox {...args} />
 
 export const Default: Story = {

--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -2,14 +2,16 @@ import React, { memo } from 'react'
 
 type CheckBoxProps = {
   label: string
+  value?: string | number
   checked?: boolean
   disabled?: boolean
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
-  style: React.CSSProperties
+  style?: React.CSSProperties
 }
 
 const CheckBox: React.FC<CheckBoxProps> = ({
   label,
+  value,
   checked,
   disabled,
   onChange,
@@ -22,6 +24,7 @@ const CheckBox: React.FC<CheckBoxProps> = ({
         disabled={disabled}
         onChange={onChange}
         type='checkbox'
+        value={value}
       />
       {label}
     </label>

--- a/src/components/Flex/index.stories.tsx
+++ b/src/components/Flex/index.stories.tsx
@@ -44,18 +44,18 @@ export default {
 type Story = StoryObj<typeof Flex>
 
 const Template = (args: {
-  justify:
+  justify?:
     | 'flex-start'
     | 'flex-end'
     | 'center'
     | 'space-between'
     | 'space-around'
-  align: 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
-  direction: 'row' | 'column' | 'row-reverse' | 'column-reverse'
-  wrap: 'nowrap' | 'wrap' | 'wrap-reverse'
-  gap: number
+  align?: 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
+  direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse'
+  wrap?: 'nowrap' | 'wrap' | 'wrap-reverse'
+  gap?: number
   children: React.ReactNode
-  style: React.CSSProperties
+  style?: React.CSSProperties
 }) => <Flex {...args} />
 
 const TemplateChildren = () => (

--- a/src/components/Flex/index.tsx
+++ b/src/components/Flex/index.tsx
@@ -1,18 +1,18 @@
 import React, { memo } from 'react'
 
 type FlexProps = {
-  justify:
+  justify?:
     | 'flex-start'
     | 'flex-end'
     | 'center'
     | 'space-between'
     | 'space-around'
-  align: 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
-  direction: 'row' | 'column' | 'row-reverse' | 'column-reverse'
-  wrap: 'nowrap' | 'wrap' | 'wrap-reverse'
-  gap: number
+  align?: 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
+  direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse'
+  wrap?: 'nowrap' | 'wrap' | 'wrap-reverse'
+  gap?: number
   children: React.ReactNode
-  style: React.CSSProperties
+  style?: React.CSSProperties
 }
 
 const Flex: React.FC<FlexProps> = ({
@@ -32,7 +32,7 @@ const Flex: React.FC<FlexProps> = ({
         alignItems: align,
         flexDirection: direction,
         flexWrap: wrap,
-        gap: `${gap * 8}px`,
+        gap: `${(gap ?? 0) * 8}px`,
         ...style
       }}>
       {children}

--- a/src/components/Radio/RadioButton.stories.tsx
+++ b/src/components/Radio/RadioButton.stories.tsx
@@ -4,7 +4,7 @@ import RadioButton from './RadioButton'
 import RadioButtonGroup from './RadioButtonGroup'
 
 export default {
-  title: 'Components/Radio/RadioButton',
+  title: 'Components/RadioButton',
   component: RadioButton,
   argTypes: {
     label: { control: 'text' },

--- a/src/modules/Home/ChartTypeRadioGroup.stories.tsx
+++ b/src/modules/Home/ChartTypeRadioGroup.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import type { StoryObj } from '@storybook/react'
+import ChartTypeRadioGroup from './ChartTypeRadioGroup'
+import { type ChartType } from './types'
+
+export default {
+  title: 'Modules/Home/ChartTypeRadioGroup',
+  component: ChartTypeRadioGroup,
+  argTypes: {}
+}
+
+type Story = StoryObj<typeof ChartTypeRadioGroup>
+
+const Template = (args: {
+  value?: ChartType
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+}) => <ChartTypeRadioGroup {...args} />
+
+export const Default: Story = {
+  args: {
+    value: undefined
+  },
+  render: Template
+}

--- a/src/modules/Home/ChartTypeRadioGroup.tsx
+++ b/src/modules/Home/ChartTypeRadioGroup.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import RadioButton from '../../components/Radio/RadioButton'
+import RadioButtonGroup from '../../components/Radio/RadioButtonGroup'
+import { type ChartType } from './types'
+
+type ChartTypeRadioGroupProps = {
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  value?: ChartType
+}
+const ChartTypeRadioGroup: React.FC<ChartTypeRadioGroupProps> = ({
+  onChange,
+  value
+}) => {
+  return (
+    <RadioButtonGroup name='chartType' onChange={onChange} value={value}>
+      <div>
+        <RadioButton label='総人口' value='totalPopulation' />
+        <RadioButton label='年少人口' value='youngerPopulation' />
+        <RadioButton label='生産年齢人口' value='workingAgePopulation' />
+        <RadioButton label='老年人口' value='elderlyPopulation' />
+      </div>
+    </RadioButtonGroup>
+  )
+}
+
+export default ChartTypeRadioGroup

--- a/src/modules/Home/CompositionChart.stories.tsx
+++ b/src/modules/Home/CompositionChart.stories.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import type { StoryObj } from '@storybook/react'
+import CompositionChart from './CompositionChart'
+import { type Middleware, SWRConfig, type SWRResponse } from 'swr'
+import { compositionsMock, prefecturesMock } from './mocks'
+import { type ChartType } from './types'
+
+export default {
+  title: 'Modules/Home/CompositionChart',
+  component: CompositionChart,
+  argTypes: {
+    prefectures: { control: 'array' },
+    type: {
+      control: 'select',
+      options: [
+        'totalPopulation',
+        'youngerPopulation',
+        'workingAgePopulation',
+        'elderlyPopulation'
+      ]
+    }
+  }
+}
+
+const mockMidleware: Middleware = () => {
+  return (key): SWRResponse<any, any> => {
+    if (key === '/api/v1/prefectures') {
+      return {
+        data: prefecturesMock,
+        error: null,
+        isValidating: false,
+        mutate: async () => {},
+        isLoading: false
+      }
+    }
+
+    return {
+      data: compositionsMock,
+      error: null,
+      isValidating: false,
+      mutate: async () => {},
+      isLoading: false
+    }
+  }
+}
+
+type Story = StoryObj<typeof CompositionChart>
+
+const Template = (args: { prefectures: number[]; type?: ChartType }) => (
+  <SWRConfig value={{ use: [mockMidleware] }}>
+    <CompositionChart prefectures={args.prefectures} type={args.type} />
+  </SWRConfig>
+)
+
+export const Default: Story = {
+  args: {
+    prefectures: [11],
+    type: 'totalPopulation'
+  },
+  render: Template
+}

--- a/src/modules/Home/CompositionChart.tsx
+++ b/src/modules/Home/CompositionChart.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import ReactECharts, { type EChartsOption } from 'echarts-for-react'
+import { useCompositions, usePrefectures } from '../../api'
+import { type ChartType } from './types'
+
+type CompositionChartProps = {
+  prefectures: number[]
+  type?: ChartType
+}
+const CompositionChart: React.FC<CompositionChartProps> = ({
+  prefectures,
+  type
+}) => {
+  const [acceptedPrefectures, setAcceptedPrefectures] = useState<number[]>([])
+  const { data: compositios, allLoad } = useCompositions(acceptedPrefectures)
+  const { data: prefecturesData } = usePrefectures()
+
+  const getPrefectureName = useCallback(
+    (prefCode: number) => {
+      return prefecturesData?.find(
+        prefecture => prefecture.prefCode === prefCode
+      )?.prefName
+    },
+    [prefecturesData]
+  )
+
+  const getTypeIndex = useCallback(() => {
+    if (type === 'totalPopulation') return 0
+    if (type === 'youngerPopulation') return 1
+    if (type === 'workingAgePopulation') return 2
+    if (type === 'elderlyPopulation') return 3
+    return 0
+  }, [type])
+
+  const currentCompositionsSeries = useCallback(() => {
+    return compositios?.map(composition => ({
+      name: getPrefectureName(composition.prefCode),
+      type: 'line',
+      data: prefectures.includes(composition.prefCode)
+        ? composition.data[getTypeIndex()].data.map(data => data.value)
+        : null
+    }))
+  }, [compositios, getPrefectureName, getTypeIndex, prefectures])
+
+  useEffect(() => {
+    setAcceptedPrefectures(prev => {
+      // prevに含まれていないprefecturesを追加
+      const newPrefectures = prefectures.filter(
+        prefCode => !prev.includes(prefCode)
+      )
+      return [...prev, ...newPrefectures]
+    })
+    void allLoad()
+  }, [allLoad, prefectures])
+
+  const getChartOptions: EChartsOption = useCallback(
+    () => ({
+      title: {
+        text: `${compositios?.[0]?.data[getTypeIndex()].label} - 推移`
+      },
+      tooltip: {
+        trigger: 'axis'
+      },
+      grid: {
+        left: '3%',
+        right: '4%',
+        bottom: '3%',
+        containLabel: true
+      },
+      xAxis: {
+        type: 'category',
+        boundaryGap: false,
+        data: compositios?.[0]?.data[0].data.map(data => data.year)
+      },
+      yAxis: {
+        type: 'value'
+      },
+      series: currentCompositionsSeries()
+    }),
+    [compositios, currentCompositionsSeries, getTypeIndex]
+  )
+  return <ReactECharts option={getChartOptions()} />
+}
+
+export default CompositionChart

--- a/src/modules/Home/PrefecturesCheckField.stories.tsx
+++ b/src/modules/Home/PrefecturesCheckField.stories.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import type { StoryObj } from '@storybook/react'
+import PrefecturesCheckField from './PrefecturesCheckField'
+import { type Middleware, SWRConfig, type SWRResponse } from 'swr'
+import { prefecturesMock } from './mocks'
+
+export default {
+  title: 'Modules/Home/PrefecturesCheckField',
+  component: PrefecturesCheckField,
+  argTypes: {
+    checkedPrefectures: { control: 'array' }
+  }
+}
+
+const mockMidleware: Middleware = () => {
+  return (): SWRResponse<any, any> => {
+    return {
+      data: prefecturesMock,
+      error: null,
+      isValidating: false,
+      mutate: async () => {},
+      isLoading: false
+    }
+  }
+}
+
+type Story = StoryObj<typeof PrefecturesCheckField>
+
+const Template = (args: {
+  checkedPrefectures?: number[]
+  // onAdd?: (prefCode: number) => void
+  // onRemove?: (prefCode: number) => void
+}) => {
+  const [checkedPrefectures, setCheckedPrefectures] = React.useState(
+    args.checkedPrefectures ?? []
+  )
+  return (
+    <SWRConfig value={{ use: [mockMidleware] }}>
+      <PrefecturesCheckField
+        checkedPrefectures={checkedPrefectures}
+        onAdd={prefCode => {
+          setCheckedPrefectures(prev => [...prev, prefCode])
+        }}
+        onRemove={prefCode => {
+          setCheckedPrefectures(prev => prev.filter(pref => pref !== prefCode))
+        }}
+      />
+    </SWRConfig>
+  )
+}
+
+export const Default: Story = {
+  args: {
+    checkedPrefectures: []
+  },
+  render: Template
+}

--- a/src/modules/Home/PrefecturesCheckField.tsx
+++ b/src/modules/Home/PrefecturesCheckField.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback } from 'react'
+import { usePrefectures } from '../../api'
+import Flex from '../../components/Flex'
+import CheckBox from '../../components/CheckBox'
+
+type PrefecturesCheckFieldProps = {
+  checkedPrefectures?: number[]
+  onAdd?: (prefCode: number) => void
+  onRemove?: (prefCode: number) => void
+}
+
+const PrefecturesCheckField: React.FC<PrefecturesCheckFieldProps> = ({
+  checkedPrefectures,
+  onAdd,
+  onRemove
+}) => {
+  const { data: prefectures } = usePrefectures()
+
+  const handleCheck = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = parseInt(e.target.value)
+      if (checkedPrefectures?.includes(value)) {
+        onRemove?.(value)
+      } else {
+        onAdd?.(value)
+      }
+    },
+    [checkedPrefectures, onAdd, onRemove]
+  )
+
+  return (
+    <Flex wrap='wrap'>
+      {prefectures?.map(prefecture => (
+        <CheckBox
+          key={prefecture.prefCode}
+          checked={checkedPrefectures?.includes(prefecture.prefCode)}
+          label={prefecture.prefName}
+          onChange={handleCheck}
+          style={{ minWidth: '96px' }}
+          value={prefecture.prefCode}
+        />
+      ))}
+    </Flex>
+  )
+}
+
+export default PrefecturesCheckField

--- a/src/modules/Home/mocks.ts
+++ b/src/modules/Home/mocks.ts
@@ -1,0 +1,484 @@
+export const prefecturesMock: any[] = [
+	{
+			prefCode: 1,
+			prefName: '北海道'
+	},
+	{
+			prefCode: 2,
+			prefName: '青森県'
+	},
+	{
+			prefCode: 3,
+			prefName: '岩手県'
+	},
+	{
+			prefCode: 4,
+			prefName: '宮城県'
+	},
+	{
+			prefCode: 5,
+			prefName: '秋田県'
+	},
+	{
+			prefCode: 6,
+			prefName: '山形県'
+	},
+	{
+			prefCode: 7,
+			prefName: '福島県'
+	},
+	{
+			prefCode: 8,
+			prefName: '茨城県'
+	},
+	{
+			prefCode: 9,
+			prefName: '栃木県'
+	},
+	{
+			prefCode: 10,
+			prefName: '群馬県'
+	},
+	{
+			prefCode: 11,
+			prefName: '埼玉県'
+	},
+	{
+			prefCode: 12,
+			prefName: '千葉県'
+	},
+	{
+			prefCode: 13,
+			prefName: '東京都'
+	},
+	{
+			prefCode: 14,
+			prefName: '神奈川県'
+	},
+	{
+			prefCode: 15,
+			prefName: '新潟県'
+	},
+	{
+			prefCode: 16,
+			prefName: '富山県'
+	},
+	{
+			prefCode: 17,
+			prefName: '石川県'
+	},
+	{
+			prefCode: 18,
+			prefName: '福井県'
+	},
+	{
+			prefCode: 19,
+			prefName: '山梨県'
+	},
+	{
+			prefCode: 20,
+			prefName: '長野県'
+	},
+	{
+			prefCode: 21,
+			prefName: '岐阜県'
+	},
+	{
+			prefCode: 22,
+			prefName: '静岡県'
+	},
+	{
+			prefCode: 23,
+			prefName: '愛知県'
+	},
+	{
+			prefCode: 24,
+			prefName: '三重県'
+	},
+	{
+			prefCode: 25,
+			prefName: '滋賀県'
+	},
+	{
+			prefCode: 26,
+			prefName: '京都府'
+	},
+	{
+			prefCode: 27,
+			prefName: '大阪府'
+	},
+	{
+			prefCode: 28,
+			prefName: '兵庫県'
+	},
+	{
+			prefCode: 29,
+			prefName: '奈良県'
+	},
+	{
+			prefCode: 30,
+			prefName: '和歌山県'
+	},
+	{
+			prefCode: 31,
+			prefName: '鳥取県'
+	},
+	{
+			prefCode: 32,
+			prefName: '島根県'
+	},
+	{
+			prefCode: 33,
+			prefName: '岡山県'
+	},
+	{
+			prefCode: 34,
+			prefName: '広島県'
+	},
+	{
+			prefCode: 35,
+			prefName: '山口県'
+	},
+	{
+			prefCode: 36,
+			prefName: '徳島県'
+	},
+	{
+			prefCode: 37,
+			prefName: '香川県'
+	},
+	{
+			prefCode: 38,
+			prefName: '愛媛県'
+	},
+	{
+			prefCode: 39,
+			prefName: '高知県'
+	},
+	{
+			prefCode: 40,
+			prefName: '福岡県'
+	},
+	{
+			prefCode: 41,
+			prefName: '佐賀県'
+	},
+	{
+			prefCode: 42,
+			prefName: '長崎県'
+	},
+	{
+			prefCode: 43,
+			prefName: '熊本県'
+	},
+	{
+			prefCode: 44,
+			prefName: '大分県'
+	},
+	{
+			prefCode: 45,
+			prefName: '宮崎県'
+	},
+	{
+			prefCode: 46,
+			prefName: '鹿児島県'
+	},
+	{
+			prefCode: 47,
+			prefName: '沖縄県'
+	}
+]
+
+export const compositionsMock: any = [
+	{
+			boundaryYear: 2020,
+			data: [
+					{
+							label: '総人口',
+							data: [
+									{
+											year: 1980,
+											value: 12817
+									},
+									{
+											year: 1985,
+											value: 12707
+									},
+									{
+											year: 1990,
+											value: 12571
+									},
+									{
+											year: 1995,
+											value: 12602
+									},
+									{
+											year: 2000,
+											value: 12199
+									},
+									{
+											year: 2005,
+											value: 11518
+									},
+									{
+											year: 2010,
+											value: 10888
+									},
+									{
+											year: 2015,
+											value: 10133
+									},
+									{
+											year: 2020,
+											value: 9302
+									},
+									{
+											year: 2025,
+											value: 8431
+									},
+									{
+											year: 2030,
+											value: 7610
+									},
+									{
+											year: 2035,
+											value: 6816
+									},
+									{
+											year: 2040,
+											value: 6048
+									},
+									{
+											year: 2045,
+											value: 5324
+									}
+							]
+					},
+					{
+							label: '年少人口',
+							data: [
+									{
+											year: 1980,
+											value: 2906,
+											rate: 22.67
+									},
+									{
+											year: 1985,
+											value: 2769,
+											rate: 21.79
+									},
+									{
+											year: 1990,
+											value: 2346,
+											rate: 18.66
+									},
+									{
+											year: 1995,
+											value: 2019,
+											rate: 16.02
+									},
+									{
+											year: 2000,
+											value: 1728,
+											rate: 14.17
+									},
+									{
+											year: 2005,
+											value: 1442,
+											rate: 12.52
+									},
+									{
+											year: 2010,
+											value: 1321,
+											rate: 12.13
+									},
+									{
+											year: 2015,
+											value: 1144,
+											rate: 11.29
+									},
+									{
+											year: 2020,
+											value: 936,
+											rate: 10.06
+									},
+									{
+											year: 2025,
+											value: 822,
+											rate: 9.75
+									},
+									{
+											year: 2030,
+											value: 705,
+											rate: 9.26
+									},
+									{
+											year: 2035,
+											value: 593,
+											rate: 8.7
+									},
+									{
+											year: 2040,
+											value: 513,
+											rate: 8.48
+									},
+									{
+											year: 2045,
+											value: 443,
+											rate: 8.32
+									}
+							]
+					},
+					{
+							label: '生産年齢人口',
+							data: [
+									{
+											year: 1980,
+											value: 8360,
+											rate: 65.23
+									},
+									{
+											year: 1985,
+											value: 8236,
+											rate: 64.81
+									},
+									{
+											year: 1990,
+											value: 8144,
+											rate: 64.78
+									},
+									{
+											year: 1995,
+											value: 8048,
+											rate: 63.86
+									},
+									{
+											year: 2000,
+											value: 7595,
+											rate: 62.26
+									},
+									{
+											year: 2005,
+											value: 7032,
+											rate: 61.05
+									},
+									{
+											year: 2010,
+											value: 6387,
+											rate: 58.66
+									},
+									{
+											year: 2015,
+											value: 5538,
+											rate: 54.65
+									},
+									{
+											year: 2020,
+											value: 4756,
+											rate: 51.13
+									},
+									{
+											year: 2025,
+											value: 4187,
+											rate: 49.66
+									},
+									{
+											year: 2030,
+											value: 3693,
+											rate: 48.53
+									},
+									{
+											year: 2035,
+											value: 3251,
+											rate: 47.7
+									},
+									{
+											year: 2040,
+											value: 2681,
+											rate: 44.33
+									},
+									{
+											year: 2045,
+											value: 2261,
+											rate: 42.47
+									}
+							]
+					},
+					{
+							label: '老年人口',
+							data: [
+									{
+											year: 1980,
+											value: 1550,
+											rate: 12.09
+									},
+									{
+											year: 1985,
+											value: 1702,
+											rate: 13.39
+									},
+									{
+											year: 1990,
+											value: 2081,
+											rate: 16.55
+									},
+									{
+											year: 1995,
+											value: 2535,
+											rate: 20.12
+									},
+									{
+											year: 2000,
+											value: 2876,
+											rate: 23.58
+									},
+									{
+											year: 2005,
+											value: 3044,
+											rate: 26.43
+									},
+									{
+											year: 2010,
+											value: 3179,
+											rate: 29.2
+									},
+									{
+											year: 2015,
+											value: 3442,
+											rate: 33.97
+									},
+									{
+											year: 2020,
+											value: 3578,
+											rate: 38.46
+									},
+									{
+											year: 2025,
+											value: 3422,
+											rate: 40.59
+									},
+									{
+											year: 2030,
+											value: 3212,
+											rate: 42.21
+									},
+									{
+											year: 2035,
+											value: 2972,
+											rate: 43.6
+									},
+									{
+											year: 2040,
+											value: 2854,
+											rate: 47.19
+									},
+									{
+											year: 2045,
+											value: 2620,
+											rate: 49.21
+									}
+							]
+					}
+			]
+	}
+]

--- a/src/modules/Home/types.ts
+++ b/src/modules/Home/types.ts
@@ -1,0 +1,1 @@
+export type ChartType =  'totalPopulation'| 'youngerPopulation' | 'workingAgePopulation'| 'elderlyPopulation'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7183,6 +7183,11 @@ eslint-compat-utils@^0.1.2:
   resolved "https://registry.yarnpkg.com/eslint-compat-utils/-/eslint-compat-utils-0.1.2.tgz#f45e3b5ced4c746c127cf724fb074cd4e730d653"
   integrity sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==
 
+eslint-config-prettier@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
+  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
+
 eslint-config-react-app@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz#ccff9fc8e36b322902844cbd79197982be355a0e"


### PR DESCRIPTION
このPRには以下の変更が含まれています。

- Homeで利用するために、Compositionを複数個取得するHookの追加
- UIコンポーネントのpropsの一部をオプションに設定。
- 都道府県を選択するモジュールパーツの追加
- 指定した都道府県コード郡の指定した情報を表示するグラフモジュールパーツの追加
- グラフの情報を選択するラジオボタンフィールドのモジュールパーツの追加
- モジュールパーツのstorybookの単体テストの追加
- 制作過程でpretiierとeslintが競合したため、eslintに競合対策プラグインを追加

#16